### PR TITLE
fix: hasSnow typo

### DIFF
--- a/config/weather.lua
+++ b/config/weather.lua
@@ -129,43 +129,43 @@ return {
                     weather = 'SNOW',
                     time = math.random(5, 10), -- Minutes
                     windSpeed = 1.0,
-                    HasSnow = true,
+                    hasSnow = true,
                 },
                 {
                     weather = 'BLIZZARD',
                     time = 14, -- Minutes
                     windSpeed = 3.0,
-                    HasSnow = true,
+                    hasSnow = true,
                 },
                 {
                     weather = 'SNOW',
                     time = 15, -- Minutes
                     windSpeed = 2.0,
-                    HasSnow = true,
+                    hasSnow = true,
                 },
                 {
                     weather = 'SNOWLIGHT',
                     time = 20, -- Minutes
                     windSpeed = 1.0,
-                    HasSnow = true,
+                    hasSnow = true,
                 },
                 {
                     weather = 'OVERCAST',
                     windSpeed = 0.5,
                     time = 15, -- Minutes
-                    HasSnow = true,
+                    hasSnow = true,
                 },
                 {
                     weather = 'CLOUDS',
                     windSpeed = 0.5,
                     time = 15, -- Minutes
-                    HasSnow = true,
+                    hasSnow = true,
                 },
                 {
                     weather = 'CLEAR',
                     windSpeed = 0.5,
                     time = 15, -- Minutes
-                    HasSnow = true,
+                    hasSnow = true,
                 },
                 {
                     weather = 'EXTRASUNNY',


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

The default configuration has a typo with a capital H for the hasSnow variable. This causes an issue with snow conditions that don't have snow on the ground greying out the game.  This corrects this issue and lets the snow work as intended.

## Checklist

<!-- Put an x if you have tested the resource works. -->

- [x] I have personally checked if the code does not break anything in the resource.
