### PR TITLE
fix: proper handling of frozen time when client joins

### DIFF
--- a/client/time.lua
+++ b/client/time.lua
@@ -33,7 +33,7 @@ AddStateBagChangeHandler('freezeTime', 'global', function(_, _, value)
     timeFrozen = value
 end)
 
-NetworkOverrideClockMillisecondsPerGameMinute(timeScale)
+NetworkOverrideClockMillisecondsPerGameMinute(timeFrozen and 99999999 or timeScale)
 
 AddStateBagChangeHandler('syncWeather', ('player:%s'):format(cache.serverId), function(_, _, value)
     if value then


### PR DESCRIPTION
## Description

I had an issue on a test server where time would be frozen according to the server, however any new client joining would still have time progress normally and couldn't be adjusted because the time was technically frozen but just wasn't processed by the client in the initial steps. This change fixes that.

## Checklist

- [X] I have personally checked if the code does not break anything in the resource.
