### PR TITLE
feat(weather): add state for individual player weather

### DIFF
--- a/client/weather.lua
+++ b/client/weather.lua
@@ -95,6 +95,7 @@ CreateThread(function ()
     setWeather(true)
 
     playerState.syncWeather = true
+    playerState.playerWeather = 'EXTRASUNNY'
 end)
 
 AddStateBagChangeHandler('syncWeather', ('player:%s'):format(cache.serverId), function(_, _, value)
@@ -102,10 +103,11 @@ AddStateBagChangeHandler('syncWeather', ('player:%s'):format(cache.serverId), fu
         SetTimeout(0, function()
             resetWeatherParticles()
             while not playerState.syncWeather do
+                local setWeather = playerState.playerWeather or 'EXTRASUNNY'
                 SetRainLevel(0.0)
-                SetWeatherTypePersist('EXTRASUNNY')
-                SetWeatherTypeNow('EXTRASUNNY')
-                SetWeatherTypeNowPersist('EXTRASUNNY')
+                SetWeatherTypePersist(setWeather)
+                SetWeatherTypeNow(setWeather)
+                SetWeatherTypeNowPersist(setWeather)
                 Wait(2500)
             end
         end)


### PR DESCRIPTION
## Description

Adds `playerWeather` state to the player to utilize when `syncWeather` is disabled on a player. Allowing modification of the weather to override to, falling back to `EXTRASUNNY` if the state doesn't exist

## Checklist

<!-- Put an x if you have tested the resource works. -->

- [x] I have personally checked if the code does not break anything in the resource.
