### PR TITLE
fix(client): sync blackout state with client

### DIFF
--- a/client/weather.lua
+++ b/client/weather.lua
@@ -96,6 +96,13 @@ CreateThread(function ()
 
     playerState.syncWeather = true
     playerState.playerWeather = 'EXTRASUNNY'
+
+    -- set blackout to the same state as server has
+    if type(blackout) == 'boolean' then
+        SetArtificialLightsState(blackout)
+    end
+
+    SetArtificialLightsStateAffectsVehicles(false)
 end)
 
 AddStateBagChangeHandler('syncWeather', ('player:%s'):format(cache.serverId), function(_, _, value)

--- a/client/weather.lua
+++ b/client/weather.lua
@@ -1,5 +1,6 @@
 local serverWeather = GlobalState.weather
 local hadSnow = false
+local blackout = GlobalState.blackout
 local playerState = LocalPlayer.state
 
 local function resetWeatherParticles()

--- a/client/weather.lua
+++ b/client/weather.lua
@@ -1,6 +1,5 @@
 local serverWeather = GlobalState.weather
 local hadSnow = false
-local blackout = GlobalState.blackout
 local playerState = LocalPlayer.state
 
 local function resetWeatherParticles()
@@ -89,7 +88,6 @@ CreateThread(function ()
     while not NetworkIsSessionStarted() do -- Possible fix for slow clients
         Wait(100)
     end
-
     SetWind(0.1)
     WaterOverrideSetStrength(0.5)
 
@@ -99,8 +97,8 @@ CreateThread(function ()
     playerState.playerWeather = 'EXTRASUNNY'
 
     -- set blackout to the same state as server has
-    if type(blackout) == 'boolean' then
-        SetArtificialLightsState(blackout)
+    if type(GlobalState.blackout) == 'boolean' then
+        SetArtificialLightsState(GlobalState.blackout)
     end
 
     SetArtificialLightsStateAffectsVehicles(false)


### PR DESCRIPTION
## Description

Fixes issue when client joins after blackout is set on server, it does not sync. Now it checks on client join for the global state of the client.

## Checklist

- [ x ] I have personally checked if the code does not break anything in the resource.
