### PR TITLE
feat(playerBlackOut): Allow toggle server wide or player only blackouts

### DIFF
--- a/client/weather.lua
+++ b/client/weather.lua
@@ -84,6 +84,14 @@ AddStateBagChangeHandler('blackOut', 'global', function(_, _, value)
     SetArtificialLightsStateAffectsVehicles(false)
 end)
 
+AddStateBagChangeHandler('playerBlackOut', ('player:%s'):format(cache.serverId), function(_, _, value)
+    if type(value) == 'boolean' then
+        SetArtificialLightsState(value)
+    end
+
+    SetArtificialLightsStateAffectsVehicles(false)
+end)
+
 CreateThread(function ()
     while not NetworkIsSessionStarted() do -- Possible fix for slow clients
         Wait(100)
@@ -94,6 +102,7 @@ CreateThread(function ()
     setWeather(true)
 
     playerState.syncWeather = true
+    playerState.playerBlackOut = false
     playerState.playerWeather = 'EXTRASUNNY'
 
     -- set blackout to the same state as server has

--- a/server/weather.lua
+++ b/server/weather.lua
@@ -84,13 +84,6 @@ lib.addCommand('weather', {
 end)
 
 lib.addCommand('blackout', {
-    help = 'Enable or disable the power blackout',
-    restricted = 'group.admin',
-}, function()
-    GlobalState.blackOut = not GlobalState.blackOut
-end)
-
-lib.addCommand('blackout', {
     help = 'Toggle server wide or player only blackout',
 	restricted = 'group.admin',
 	params = {

--- a/server/weather.lua
+++ b/server/weather.lua
@@ -90,6 +90,22 @@ lib.addCommand('blackout', {
     GlobalState.blackOut = not GlobalState.blackOut
 end)
 
+lib.addCommand('blackout', {
+    help = 'Toggle server wide or player only blackout',
+	restricted = 'group.admin',
+	params = {
+		{ name = 'target', type = 'playerId', help = 'Target player\'s server id', optional = true },
+	}
+}, function(source, args)
+	if not args.target then
+		GlobalState.blackOut = not GlobalState.blackOut
+	else
+		local playerState = Player(args.target)
+        if not playerState then return end
+        playerState.state:set('playerBlackOut', not playerState.state?.playerBlackOut, true)
+	end
+end)
+
 -- Scheduled restart --
 if useScheduledWeather then
     AddEventHandler('txAdmin:events:scheduledRestart', function(eventData)


### PR DESCRIPTION
## Description
Adds the option to give only a specific player a blackout (usefull for heists, rp scenes ect..)

## Checklist
- [x] I have personally checked if the code does not break anything in the resource.
